### PR TITLE
Retry to receive bucets from db

### DIFF
--- a/influxdb.cpp
+++ b/influxdb.cpp
@@ -245,6 +245,19 @@ void InfluxDB::onReplyBucketFinnished()
     {
         qDebug() << "InfluxDb - error receiving buckets: " << reply->errorString();
         reply->deleteLater();
+        retryReceiveBuckets_ -= 1;
+        if(retryReceiveBuckets_ > 0)
+        {
+            qDebug() << "Retry: " << retryReceiveBuckets_ << ", to receive bucket in 20 seconds";
+            int twentySeconds = 20 * 1000;
+            QTimer::singleShot(twentySeconds, this, [this](){
+                getBuckets(bucket_);
+            });
+        }
+        else
+        {
+            qDebug() << "Unable to receive bucket, max retries exhausted.";
+        }
         return;
     }
 

--- a/influxdb.h
+++ b/influxdb.h
@@ -108,6 +108,7 @@ private:
     int bulkUpdateTimeMs_ = 0;
     qint64 lastUpdateMs_ = 0;
     QByteArray requestBuffer_ = {};
+    int retryReceiveBuckets_ = 10;
 
 };
 


### PR DESCRIPTION
When started at boot, it is possible the call to receive buckets is done before influxdb is ready. If it is not ready no update is then posted to the db later. Then by adding retry for this an application can try several times to get the bucket it need. Then it can start to post updates when the db is ready instead of end up in a failed state.